### PR TITLE
let the caller handle ConcurrentModificationException in transactions

### DIFF
--- a/src/test/java/com/googlecode/objectify/test/TransactionTests.java
+++ b/src/test/java/com/googlecode/objectify/test/TransactionTests.java
@@ -280,7 +280,7 @@ public class TransactionTests extends TestBase
 			});
 		} catch (ConcurrentModificationException e) {}
 
-		assert counter.counter == 3;
+		assert counter.counter == 1;
 	}
 
 	public static class SimpleCommitListener implements Runnable {
@@ -351,8 +351,9 @@ public class TransactionTests extends TestBase
 	}
 
 	/**
+	 * @NorbertParrag: 2020.02.12. I removed ConcurrentModificationException retry mechanism, we got to many of them in Aodocs
 	 */
-	@Test
+	@Test(enabled = false)
 	public void listenerIsOnlyCalledOnceIfTransactionRetries() {
 		final CommitCountListener listener = new CommitCountListener();
 		final Counter counter = new Counter();
@@ -407,8 +408,9 @@ public class TransactionTests extends TestBase
 	}
 
 	/**
+	 * @NorbertParrag: 2020.02.12. I removed ConcurrentModificationException retry mechanism, we got to many of them in Aodocs
 	 */
-	@Test
+	@Test(enabled = false)
 	public void listenerIsOnlyCalledOnceIfTransactionRetriesFromOrganicConcurrencyFailure() {
 		fact().register(Trivial.class);
 


### PR DESCRIPTION
If several instances try to write the same entity in a transaction it can cause contention on that entity. In case of contention the current code retries the operation endlessly without any wait period which makes the contention even worse. This makes it impossible for any transaction to successfully write the entity which leads to an endless loop of transaction retries.

We must use exponential backoff between transaction retries to ease the load on datastore.